### PR TITLE
Added Florida Gators theme to themes.yml

### DIFF
--- a/data/themes.yml
+++ b/data/themes.yml
@@ -150,3 +150,4 @@
 - { colors: '#40415a,#54556e,#f99a66,#ffffff,#54556e,#ffffff,#d55161,#d55161', name: 'devRant' }
 - { colors: '#6044db,#500ba3,#f0b31a,#FFFFFF,#997929,#ffffff,#f0b31a,#a92ab0', name: 'Mautic' }
 - { colors: '#6fa36f,#3E313C,#01690b,#ffff00,#3E313C,#ffffff,#faff78,#ed687e', name: 'Drupal Twig'}
+- { colors: '#014A83,#053354,#dd661e,#ffffff,#053354,#ffffff,#dd661e,#dd661e', name: 'Florida Gators'}


### PR DESCRIPTION
Added orange and blue color scheme that matches the University of Florida's branding.