### PR TITLE
Add milligram.io inspired colour scheme

### DIFF
--- a/data/themes.yml
+++ b/data/themes.yml
@@ -225,3 +225,4 @@
 - { colors: '#308390,#1BD9C4,#1BD9C4,#FFFFFF,#40C1BB,#f0f0f4,#1bd9c4,#DB6668', name: 'WillowTree - Dark' }
 - { colors: '#121417,#2F343D,#2F343D,#ABB2BF,#2F343D,#ABB2BF,#98C379,#98C379', name: 'Atom One Dark' }
 - { colors: '#333333,#85714D,#85714D,#FFFFFF,#85714D,#FFFFFF,#E31837,#E31837', name: 'Vegas Golden Knights' }
+- { colors: '#F4F5F6,#FFFFFF,#9B4DCA,#ffffff,#FFFFFF,#606c76,#9B4DCA,#9B4DCA', name: 'Milligram.io'}


### PR DESCRIPTION
I've been using this theme since I found the milligram css framework, it's very simple and uses simple purples and greys. It fits together nicely with a couple of tweaks to the colours so they're a bit easier on the eyes.

Love this project!