### PR TITLE
Add "Seoul256 Dark" theme

### DIFF
--- a/data/themes.yml
+++ b/data/themes.yml
@@ -253,3 +253,4 @@
 - { colors: '#222222,#333333,#9FC65D,#FFFFFF,#4A5664,#F4F4F4,#9FC65D,#ffbc3b', name: 'Inpsyde' }
 - { colors: '#2e4f7e,#2C3849,#203251,#FFFFFF,#456494,#FFFFFF,#a6c056,#e9ae4c', name: 'Visual Composer' }
 - { colors: '#323232,#E60A00,#E60A00,#FFFFFF,#505050,#F5F5F5,#E64600,#E60A00', name: '360Channel' }
+- { colors: '#3a3a3a,#875f5f,#005e5f,#ffffff,#005e5f,#d0d0d0,#87af87,#875f5f', name: 'Seoul256 Dark' }


### PR DESCRIPTION
Add Seoul256 Dark theme based on the vim theme https://github.com/junegunn/seoul256.vim.

## Preview
<img width="220" alt="screen shot 2018-11-19 at 9 52 20 am" src="https://user-images.githubusercontent.com/238929/48722301-eb703080-ebe0-11e8-8374-e8172dafed35.png">
