### PR TITLE
Add Seoul256 themes

### DIFF
--- a/data/themes.yml
+++ b/data/themes.yml
@@ -253,3 +253,5 @@
 - { colors: '#222222,#333333,#9FC65D,#FFFFFF,#4A5664,#F4F4F4,#9FC65D,#ffbc3b', name: 'Inpsyde' }
 - { colors: '#2e4f7e,#2C3849,#203251,#FFFFFF,#456494,#FFFFFF,#a6c056,#e9ae4c', name: 'Visual Composer' }
 - { colors: '#323232,#E60A00,#E60A00,#FFFFFF,#505050,#F5F5F5,#E64600,#E60A00', name: '360Channel' }
+- { colors: '#dadada,#c6c6c6,#875f5f,#dadada,#c6c6c6,#4e4e4e,#8bb898,#028787', name: 'Seoul Light' }
+- { colors: '#3a3a3a,#444444,#875f5f,#c3c3c3,#444444,#c3c3c3,#8bb898,#028787', name: 'Seoul Dark' }


### PR DESCRIPTION
Add light and dark seoul256 themes.

## Dark

<img width="220" alt="screen shot 2018-11-19 at 10 55 49 am" src="https://user-images.githubusercontent.com/238929/48725551-c3d19600-ebe9-11e8-8c0c-be8c683b41f4.png">

## Light

<img width="219" alt="screen shot 2018-11-19 at 10 55 29 am" src="https://user-images.githubusercontent.com/238929/48725561-c8964a00-ebe9-11e8-969a-f94e77c51020.png">
