### PR TITLE
Make sure that the default theme is the first one listed in themes.yml

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -105,4 +105,12 @@ helpers do
         ))
     end
   end
+
+  def default_theme
+    theme = data.themes.first
+    OpenStruct.new(theme.merge(
+      slug: theme['name'].parameterize.underscore,
+      digest: Digest::MD5.new.hexdigest(theme['colors'])
+    ))
+  end
 end

--- a/source/javascripts/all.js.erb
+++ b/source/javascripts/all.js.erb
@@ -9,10 +9,10 @@ app.config(['$stateProvider', '$urlRouterProvider',
                 url: "/:slug",
                 controller: 'ThemeController',
                 params: {
-                    slug: { value: '<%= themes.first.slug %>' }
+                    slug: { value: '<%= default_theme.slug %>' }
                 }
             });
-        $urlRouterProvider.otherwise('/<%= themes.first.slug %>');
+        $urlRouterProvider.otherwise('/<%= default_theme.slug %>');
     }]);
 
 app.controller('ThemeController', ['$scope', '$stateParams', '$state', '$location',


### PR DESCRIPTION
We want the default theme to be Aubergine since that is the default that comes
with Slack. However, we were actually relying on the first theme in alphabetical
sorted order as the default theme, which ended up changing the default as themes
got added.

This patch always makes it the first entry in the themes.yml file