### PR TITLE
bugfix/typo: correct the homepage url link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-<a href="https://http://slackthemes.net" target="_blank"><img src="https://raw.githubusercontent.com/paracycle/slackthemes/master/source/favicon-32.png"></a>
+<a href="https://slackthemes.net" target="_blank"><img src="https://raw.githubusercontent.com/paracycle/slackthemes/master/source/favicon-32.png"></a>
 <br /><strong>Slack Themes</strong>
 </p>
 <p align="center">


### PR DESCRIPTION
- change the url  `http://https://slackthemes.net` to the correct `https://slackthemes.net` url