### PR TITLE
Adding UC Davis theme

### DIFF
--- a/data/themes.yml
+++ b/data/themes.yml
@@ -63,6 +63,7 @@
 - { colors: '#073642,#002B36,#B58900,#FDF6E3,#CB4B16,#FDF6E3,#2AA198,#DC322F', name: 'Solarized Dark' }
 - { colors: '#293134,#2F393C,#293134,#93C763,#2F393C,#81969A,#EC7600,#EC7600', name: 'Son of Obsidian' }
 - { colors: '#000000,#A51C24,#FFFFFF,#0320FF,#A5A5A5,#FFFFFF,#FFFFFF,#FFFF00', name: 'Stark Contrast' }
+- { colors: '#5E2E00,#4E0A15,#BC9B5F,#FFFFFF,#8D7165,#FFFFFF,#898D72,#CA9A00', name: 'Steampunk' }
 - { colors: '#B300B3,#23A61C,#FFFFFF,#C400FF,#FF2EFF,#000000,#F7FF00,#F7FF00', name: 'Summer Craze' }
 - { colors: '#574f4a,#48b9c7,#faa41a,#FFFFFF,#48b9c7,#FFFFFF,#26d076,#dc4405', name: 'System76' }
 - { colors: '#000000,#000000,#1EB8EB,#000000,#424242,#FFFFFF,#1EB8EB,#1EB8EB', name: 'Tron' }


### PR DESCRIPTION
Adding a theme for the University of California at Davis. May be applicable to other UC campuses as well (the blue and gold colors are similar -- not sure they are identical). Also, vi insists on adding a linebreak at the end.