### PR TITLE
Add Origamid Next theme

### DIFF
--- a/data/themes.yml
+++ b/data/themes.yml
@@ -255,3 +255,4 @@
 - { colors: '#323232,#E60A00,#E60A00,#FFFFFF,#505050,#F5F5F5,#E64600,#E60A00', name: '360Channel' }
 - { colors: '#000639,#3E313C,#108043,#FFFFFF,#173630,#FFFFFF,#50B83C,#9C6ADE', name: 'Shopify' }
 - { colors: '#100E0E,#C10800,#FFB400,#FFFFFF,#242121,#FFFFFF,#FF2B22,#FF2B22', name: 'RubyConf' }
+- { colors: '#111111,#333333,#333333,#ffffff,#333333,#888888,#333333,#333333', name: 'Origamid Next' }


### PR DESCRIPTION
Added Origamid Next theme, based on the same theme for VS Code:

https://marketplace.visualstudio.com/items?itemName=origamid.origamid-next
https://github.com/origamid/origamid-next-vscode