### PR TITLE
Add Quietude Dark and Light themes

### DIFF
--- a/data/themes.yml
+++ b/data/themes.yml
@@ -255,3 +255,5 @@
 - { colors: '#323232,#E60A00,#E60A00,#FFFFFF,#505050,#F5F5F5,#E64600,#E60A00', name: '360Channel' }
 - { colors: '#000639,#3E313C,#108043,#FFFFFF,#173630,#FFFFFF,#50B83C,#9C6ADE', name: 'Shopify' }
 - { colors: '#100E0E,#C10800,#FFB400,#FFFFFF,#242121,#FFFFFF,#FF2B22,#FF2B22', name: 'RubyConf' }
+- { colors: '#1A1D21,#F8F8FA,#1A1D21,#FFFFFF,#FFFFFF,#CCCCCC,#2288CC,#333333', name: 'Quietude Dark' }
+- { colors: '#FFFFFF,#F4F4F4,#FFFFFF,#333333,#FFFFFF,#333333,#2288CC,#999999', name: 'Quietude Light' }


### PR DESCRIPTION
Designed for minimal distraction. Best used with "Show unread only" enabled for all channel groups, "All Unreads" enabled, and any irritating alert- or bot-based channels muted. Stop letting Slack run your day!